### PR TITLE
Prompt for receipt and generate thermal PDF after payments

### DIFF
--- a/src/components/modals/ReceiptPromptModal.jsx
+++ b/src/components/modals/ReceiptPromptModal.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
+import { Loader2, Printer } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const PAPER_OPTIONS = [
+  { label: '58 mm', value: 58 },
+  { label: '80 mm', value: 80 },
+];
+
+const ReceiptPromptModal = ({
+  isOpen,
+  isGenerating,
+  paperWidth,
+  onPaperWidthChange,
+  onConfirm,
+  onCancel,
+  hasPreviousReceipt,
+  onOpenPreviousReceipt,
+}) => {
+  const handleOpenChange = (open) => {
+    if (!open && !isGenerating) {
+      onCancel();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className={cn(
+          'max-w-[90vw] sm:max-w-md rounded-xl shadow-xl border bg-white p-0',
+          'data-[state=open]:animate-in data-[state=open]:zoom-in-95 data-[state=open]:fade-in-0',
+          'data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=closed]:fade-out-0'
+        )}
+      >
+        <DialogHeader className="px-6 pt-6 pb-4">
+          <DialogTitle className="text-xl font-semibold text-brand-blue flex items-center gap-2">
+            <Printer className="h-5 w-5 text-brand-green" />
+            Finalizar Pedido
+          </DialogTitle>
+          <DialogDescription className="text-sm text-gray-600">
+            ¿Deseas generar recibo?
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="px-6 pb-2">
+          <div className="mb-4">
+            <Label className="text-sm font-medium text-gray-700 mb-2 block">Formato de papel</Label>
+            <RadioGroup
+              value={String(paperWidth)}
+              onValueChange={(value) => onPaperWidthChange(Number(value))}
+              className="grid grid-cols-2 gap-2"
+              disabled={isGenerating}
+            >
+              {PAPER_OPTIONS.map((option) => (
+                <Label
+                  key={option.value}
+                  htmlFor={`receipt-paper-${option.value}`}
+                  className={cn(
+                    'flex items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium transition-colors',
+                    valueIsSelected(paperWidth, option.value)
+                      ? 'border-brand-green bg-brand-green/10 text-brand-green shadow-sm'
+                      : 'border-gray-200 bg-gray-50 text-gray-700 hover:border-brand-green/40 hover:bg-brand-green/5'
+                  )}
+                >
+                  <RadioGroupItem
+                    id={`receipt-paper-${option.value}`}
+                    value={String(option.value)}
+                    className="sr-only"
+                  />
+                  {option.label}
+                </Label>
+              ))}
+            </RadioGroup>
+          </div>
+
+          {hasPreviousReceipt && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onOpenPreviousReceipt}
+              disabled={isGenerating}
+              className="w-full justify-center text-sm mb-4"
+            >
+              Volver a abrir último recibo
+            </Button>
+          )}
+        </div>
+
+        <DialogFooter className="px-6 pb-6 flex flex-col sm:flex-row gap-2 sm:gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={isGenerating}
+            className="w-full sm:w-auto border-gray-300 text-gray-700"
+          >
+            No
+          </Button>
+          <Button
+            type="button"
+            onClick={onConfirm}
+            disabled={isGenerating}
+            className="w-full sm:w-auto bg-brand-green text-white hover:bg-brand-green/90"
+          >
+            {isGenerating ? (
+              <span className="flex items-center gap-2 text-sm">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Generando...
+              </span>
+            ) : (
+              'Sí, generar'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const valueIsSelected = (currentValue, optionValue) => Number(currentValue) === Number(optionValue);
+
+export default ReceiptPromptModal;

--- a/src/lib/receiptGenerator.js
+++ b/src/lib/receiptGenerator.js
@@ -1,0 +1,189 @@
+import { jsPDF } from 'jspdf';
+
+const DEFAULT_MARGIN = 4;
+const LINE_HEIGHT = 4.2;
+
+const formatCurrency = (value, currency = 'MXN') => {
+  try {
+    return new Intl.NumberFormat('es-MX', {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 2,
+    }).format(Number(value) || 0);
+  } catch (error) {
+    return `$${(Number(value) || 0).toFixed(2)}`;
+  }
+};
+
+const drawDivider = (doc, pageWidth, cursorY, margin = DEFAULT_MARGIN) => {
+  doc.setLineWidth(0.2);
+  doc.setLineDash([1, 1], 0);
+  doc.line(margin, cursorY, pageWidth - margin, cursorY);
+  doc.setLineDash();
+  return cursorY + 2.5;
+};
+
+const addWrappedText = (doc, text, x, y, maxWidth, options = {}) => {
+  const lines = doc.splitTextToSize(text, maxWidth);
+  lines.forEach((line, index) => {
+    doc.text(line, x, y + index * (LINE_HEIGHT - 0.6), options);
+  });
+  return y + (lines.length - 1) * (LINE_HEIGHT - 0.6);
+};
+
+export const generateThermalReceiptPdf = (order, { paperWidthMM = 58 } = {}) => {
+  if (!order) {
+    throw new Error('No se encontró información del pedido para generar el recibo.');
+  }
+
+  const doc = new jsPDF({
+    unit: 'mm',
+    format: [paperWidthMM, 200],
+  });
+
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const margin = DEFAULT_MARGIN;
+  let cursorY = margin + 1;
+  const contentWidth = pageWidth - margin * 2;
+  const currency = order.payment?.currency || 'MXN';
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(12);
+  doc.text(order.store?.name || 'Recibo', pageWidth / 2, cursorY, { align: 'center' });
+  cursorY += LINE_HEIGHT;
+
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(9);
+  [order.store?.address, order.store?.phone, order.store?.rfc]
+    .filter(Boolean)
+    .forEach((line) => {
+      cursorY = addWrappedText(doc, line, pageWidth / 2, cursorY, contentWidth, { align: 'center' });
+      cursorY += LINE_HEIGHT - 1.2;
+    });
+
+  cursorY += 0.5;
+  cursorY = drawDivider(doc, pageWidth, cursorY, margin);
+  cursorY += 1;
+
+  const createdAtDate = order.createdAt ? new Date(order.createdAt) : new Date();
+  const formattedDate = `${createdAtDate.toLocaleDateString()} ${createdAtDate.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  })}`;
+
+  doc.text(`Folio: ${order.id || 'N/A'}`, margin, cursorY);
+  cursorY += LINE_HEIGHT - 1;
+  cursorY = addWrappedText(doc, `Fecha: ${formattedDate}`, margin, cursorY, contentWidth);
+  cursorY += LINE_HEIGHT - 1;
+  doc.text(`Pago: ${order.payment?.method || 'N/A'}`, margin, cursorY);
+  cursorY += LINE_HEIGHT;
+
+  cursorY = drawDivider(doc, pageWidth, cursorY, margin);
+  cursorY += 1;
+
+  order.items.forEach((item) => {
+    const addonsTotal = (item.addons || []).reduce((sum, addon) => sum + (Number(addon.price) || 0), 0);
+    const lineTotal = item.unitPrice * item.qty + addonsTotal;
+    const lineText = `${item.qty} x ${item.name}`;
+    const lineMaxWidth = contentWidth - 16;
+    const startY = cursorY;
+
+    const lines = doc.splitTextToSize(lineText, lineMaxWidth);
+    lines.forEach((line, index) => {
+      const yPos = startY + index * (LINE_HEIGHT - 0.6);
+      doc.text(line, margin, yPos);
+      if (index === 0) {
+        doc.text(formatCurrency(lineTotal, currency), pageWidth - margin, yPos, { align: 'right' });
+      }
+    });
+
+    cursorY = startY + (lines.length - 1) * (LINE_HEIGHT - 0.6) + LINE_HEIGHT - 0.6;
+
+    if (item.addons && item.addons.length > 0) {
+      doc.setFontSize(8);
+      item.addons.forEach((addon) => {
+        const addonLines = doc.splitTextToSize(addon.name, lineMaxWidth);
+        addonLines.forEach((addonLine, index) => {
+          const addonY = cursorY + index * (LINE_HEIGHT - 1);
+          doc.text(addonLine, margin + 3, addonY);
+          if (index === 0) {
+            doc.text(formatCurrency(addon.price || 0, currency), pageWidth - margin, addonY, { align: 'right' });
+          }
+        });
+        cursorY += addonLines.length * (LINE_HEIGHT - 1);
+      });
+      doc.setFontSize(9);
+    }
+
+    if (item.notes) {
+      doc.setFontSize(8);
+      cursorY = addWrappedText(doc, `Nota: ${item.notes}`, margin + 3, cursorY, lineMaxWidth);
+      cursorY += LINE_HEIGHT - 1.5;
+      doc.setFontSize(9);
+    }
+
+    cursorY += 0.5;
+  });
+
+  cursorY = drawDivider(doc, pageWidth, cursorY, margin);
+  cursorY += LINE_HEIGHT - 1;
+
+  const addSummaryLine = (label, value, emphasis = false) => {
+    if (value == null) return;
+    if (emphasis) {
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(11);
+    } else {
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(9);
+    }
+    doc.text(label, margin, cursorY);
+    doc.text(formatCurrency(value, currency), pageWidth - margin, cursorY, { align: 'right' });
+    cursorY += emphasis ? LINE_HEIGHT + 0.5 : LINE_HEIGHT - 0.8;
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(9);
+  };
+
+  addSummaryLine('Subtotal', order.subtotal);
+  if (order.discount) {
+    addSummaryLine('Descuento', -Math.abs(order.discount));
+  }
+  if (order.taxes) {
+    addSummaryLine('Impuestos', order.taxes);
+  }
+  addSummaryLine('TOTAL', order.total, true);
+
+  if (order.payment?.method === 'EFECTIVO' || order.payment?.method === 'DOLARES') {
+    if (order.payment?.cashGiven != null) {
+      addSummaryLine('Recibido', order.payment.cashGiven);
+    }
+    if (order.payment?.change != null) {
+      addSummaryLine('Cambio', order.payment.change);
+    }
+  }
+
+  cursorY = drawDivider(doc, pageWidth, cursorY, margin);
+  cursorY += LINE_HEIGHT - 1;
+
+  if (order.customerName) {
+    cursorY = addWrappedText(doc, `Cliente: ${order.customerName}`, margin, cursorY, contentWidth);
+    cursorY += LINE_HEIGHT - 1;
+  }
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(10);
+  cursorY = addWrappedText(doc, '¡Gracias por su compra!', pageWidth / 2, cursorY, contentWidth, { align: 'center' });
+  cursorY += LINE_HEIGHT;
+
+  const finalHeight = cursorY + margin;
+  if (doc.internal.pageSize.getHeight() !== finalHeight) {
+    doc.internal.pageSize.setHeight(finalHeight);
+  }
+
+  const blob = doc.output('blob');
+  const objectUrl = URL.createObjectURL(blob);
+
+  return { blob, url: objectUrl, doc };
+};
+
+export const THERMAL_PAPER_WIDTHS = [58, 80];


### PR DESCRIPTION
## Summary
- add a reusable receipt prompt modal that matches the POS styling, lets the cashier pick the thermal paper width, and re-open the most recent receipt
- create a client-side thermal receipt PDF generator that formats store, item, totals, and payment details for 58 mm and 80 mm rolls
- update the POS checkout flow to await payment confirmation, surface the receipt prompt, persist preferences, and launch the generated PDF in a new tab with helpful toasts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccdc25f59c832db0888c12ff936484